### PR TITLE
remove padding bytes to correct lighting

### DIFF
--- a/quantized_mesh_tile/terrain.py
+++ b/quantized_mesh_tile/terrain.py
@@ -554,12 +554,8 @@ class TerrainTile(object):
             # Unsigned char size len is 1
             f.write(packEntry(meta['extensionLength'], 2 * vertexCount))
 
-            # Add 2 bytes of padding
-            f.write(packEntry('B', 1))
-            f.write(packEntry('B', 1))
-
             metaV = TerrainTile.OctEncodedVertexNormals
-            for i in xrange(0, vertexCount - 1):
+            for i in xrange(0, vertexCount):
                 x, y = octEncode(self.vLight[i])
                 f.write(packEntry(metaV['xy'], x))
                 f.write(packEntry(metaV['xy'], y))


### PR DESCRIPTION
hi, 

removing of extra-padding bytes and fixing the loop produce correct normal values.

Tested with bavarian dem-data and elevation-styled material
![correct_lighting](https://user-images.githubusercontent.com/2117317/36976108-b6d9b088-207c-11e8-94da-35b0d367d5ab.png)

